### PR TITLE
Fix Compiling use National

### DIFF
--- a/cobc/typeck.c
+++ b/cobc/typeck.c
@@ -8973,6 +8973,16 @@ validate_move (cb_tree src, cb_tree dst, const unsigned int is_value, int *move_
 
 			/* Value check */
 			switch (CB_TREE_CATEGORY (dst)) {
+			case CB_CATEGORY_NATIONAL:
+			case CB_CATEGORY_NATIONAL_EDITED:
+				if (is_value) {
+					goto expect_national;
+				}
+
+				if (l->scale == 0) {
+					goto expect_national;
+				}
+				goto non_integer_move;
 			case CB_CATEGORY_ALPHANUMERIC:
 			case CB_CATEGORY_ALPHANUMERIC_EDITED:
 				if (is_value) {


### PR DESCRIPTION
* コンパイル時にPIC Nがあってもエラーにならないように修正
* この修正はコンパイル時のみのものとなっていて、MOVEなどの処理は未修正