### PR TITLE
Fix cob_sys_rename_file

### DIFF
--- a/libcob/fileio.c
+++ b/libcob/fileio.c
@@ -6379,7 +6379,12 @@ cob_sys_rename_file (unsigned char *fname1, unsigned char *fname2)
 
 	ret = rename (localbuff, file_open_name);
 	if (ret) {
-		return 128;
+		switch (errno) {
+		case ENOENT:
+			return 14605; //MicroFocus file status 9-013
+		default:
+			return 128;
+		}
 	}
 	return 0;
 }


### PR DESCRIPTION
* リネームを行う際にファイルが見つからなかった場合に別のステータスを返すように修正
* 暫定的にMFと同様のファイルステータス9-013を返すようにした