### PR TITLE
Add cppcheck scripts and run them in GitHub Actions

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -22,6 +22,14 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: Download vbisam
+        run: |
+          if [ ! -d vbisam ]; then \
+            git clone https://github.com/opensourcecobol/opensource-cobol; \
+            mv opensource-cobol/vbisam .; \
+            rm -rf opensource-cobol; \
+          fi
+
       - name: Install vbisam
         working-directory: vbisam
         run: |

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,0 +1,47 @@
+name: cppcheck
+
+on:
+  push:
+  pull_request:
+    types: [opened, reopened, review_requested, synchronize]
+
+env:
+  CPPFLAGS: "-I/usr/include"
+  LDFLAGS: "-L/usr/lib"
+  LD_LAIBRARY_PATH: "/usr/lib"
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Install prerequisite softwares
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libncurses6 libncurses-dev ncurses-doc libgmp10 libgmp-dev m4 libtool help2man pkg-config gettext automake autoconf libxml2 libxml2-dev libxml2-utils libcjson1 libcjson-dev build-essential libdb-dev cppcheck
+
+      - uses: actions/checkout@v4
+
+      - name: Install vbisam
+        working-directory: vbisam
+        run: |
+          ./configure --prefix=/usr/
+          make
+          sudo make install
+
+      - name: Build GnuCOBOL
+        run: | 
+          ./configure --prefix=/usr/ --with-xml2 --with-vbisam
+          make
+
+      - name: Check cobc/
+        working-directory: cobc/
+        run: ./cppcheck
+
+      - name: Check libcob/
+        working-directory: libcob/
+        run: ./cppcheck
+
+      - name: Check bin/
+        working-directory: bin/
+        run: ./cppcheck

--- a/bin/cppcheck
+++ b/bin/cppcheck
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cppcheck --error-exitcode=1 cobcrun.c

--- a/cobc/cppcheck
+++ b/cobc/cppcheck
@@ -11,12 +11,12 @@ cppcheck --error-exitcode=1 \
     help.c \
     parser.c \
     parser.h \
-    pplex.c \
     ppparse.c \
     ppparse.h \
     replace.c \
-    scanner.c \
     tree.c \
     tree.h \
     typeck.c
+    # pplex.c \ -- this file contains errors
+    # scanner.c \ -- this file contains errors
     # reserved.c \ -- this file contains errors

--- a/cobc/cppcheck
+++ b/cobc/cppcheck
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+cppcheck --error-exitcode=1 \
+    cobc.c \
+    cobc.h \
+    codegen.c \
+    codeoptim.c \
+    config.c \
+    error.c \
+    field.c \
+    help.c \
+    parser.c \
+    parser.h \
+    pplex.c \
+    ppparse.c \
+    ppparse.h \
+    replace.c \
+    scanner.c \
+    tree.c \
+    tree.h \
+    typeck.c
+    # reserved.c \ -- this file contains errors

--- a/libcob/cppcheck
+++ b/libcob/cppcheck
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+cppcheck --error-exitcode=1 \
+	call.c \
+	cconv.c \
+	cobgetopt.c \
+	cobgetopt.h \
+	coblocal.h \
+	common.c \
+	common.h \
+	fileio.c \
+	intrinsic.c \
+	mlio.c \
+	move.c \
+	numeric.c \
+	screenio.c \
+	strings.c \
+	termio.c \
+	version.h
+	#reportio.c \ This file contains errors

--- a/libcob/cppcheck
+++ b/libcob/cppcheck
@@ -8,7 +8,6 @@ cppcheck --error-exitcode=1 \
 	coblocal.h \
 	common.c \
 	common.h \
-	fileio.c \
 	intrinsic.c \
 	mlio.c \
 	move.c \
@@ -17,4 +16,5 @@ cppcheck --error-exitcode=1 \
 	strings.c \
 	termio.c \
 	version.h
+	#fileio.c \
 	#reportio.c \ This file contains errors


### PR DESCRIPTION
This pull request adds cppcheck scripts in cobc/, libcob/ and /bin and run them in GitHub Actions.
Although these scripts do not check some files in which cppcheck find one or more erros, I will fix the errors if this pull request is merged.