### PR TITLE
EXCLUSIVE LOCK for OPEN INPUT

### DIFF
--- a/libcob/fileio.c
+++ b/libcob/fileio.c
@@ -1909,9 +1909,17 @@ cob_file_open (cob_file *f, char *filename,
 	switch (mode) {
 	case COB_OPEN_INPUT:
 		if (!cobsetptr->cob_unix_lf) {
-			fmode = "r";
+			if (f->lock_mode & COB_LOCK_EXCLUSIVE) {
+				fmode = "r+";
+			} else {
+				fmode = "r";
+			}
 		} else {
-			fmode = "rb";
+			if (f->lock_mode & COB_LOCK_EXCLUSIVE) {
+				fmode = "rb+";
+			} else {
+				fmode = "rb";
+			}
 		}
 		break;
 	case COB_OPEN_OUTPUT:
@@ -2014,7 +2022,7 @@ cob_file_open (cob_file *f, char *filename,
 	if (fp && memcmp (filename, "/dev/", (size_t)5)) {
 		struct flock		lock;
 		memset ((void *)&lock, 0, sizeof (struct flock));
-		if (mode != COB_OPEN_INPUT) {
+		if ((mode != COB_OPEN_INPUT) || (f->lock_mode & COB_LOCK_EXCLUSIVE)) {
 			lock.l_type = F_WRLCK;
 		} else {
 			lock.l_type = F_RDLCK;

--- a/libcob/fileio.c
+++ b/libcob/fileio.c
@@ -1640,7 +1640,12 @@ cob_fd_file_open (cob_file *f, char *filename,
 	fperms = 0;
 	switch (mode) {
 	case COB_OPEN_INPUT:
-		fdmode |= O_RDONLY;
+		if (f->lock_mode & COB_LOCK_EXCLUSIVE) {
+			/* for fcntl write lock */
+			fdmode |= O_RDWR;	
+		} else {
+			fdmode |= O_RDONLY;
+		}
 		break;
 	case COB_OPEN_OUTPUT:
 		nonexistent = 0;
@@ -1753,7 +1758,7 @@ cob_fd_file_open (cob_file *f, char *filename,
 	if (memcmp (filename, "/dev/", (size_t)5)) {
 		struct flock	lock;
 		memset ((void *)&lock, 0, sizeof (struct flock));
-		if (mode != COB_OPEN_INPUT) {
+		if ((mode != COB_OPEN_INPUT) || (f->lock_mode & COB_LOCK_EXCLUSIVE)) {
 			lock.l_type = F_WRLCK;
 		} else {
 			lock.l_type = F_RDLCK;

--- a/tests/testsuite.src/run_file.at
+++ b/tests/testsuite.src/run_file.at
@@ -5567,8 +5567,6 @@ AT_CLEANUP
 AT_SETUP([SEQUENTIAL file with LOCK MODE EXCLUSIVE])
 AT_KEYWORDS([runfile])
 
-AT_XFAIL_IF([true])
-
 AT_DATA([prog1.cob], [
        identification division.
        program-id. prog1.


### PR DESCRIPTION
* issue #20 
* Implemented to exclusive lock (write lock) when EXCLUSIVE LOCK is set in case of INPUT OPEN Sequential and Relative files.