### PR TITLE
Implemented the CANCEL ALL function

### DIFF
--- a/libcob/common.c
+++ b/libcob/common.c
@@ -3255,6 +3255,9 @@ cob_module_global_enter (cob_module **module, cob_global **mglobal,
 	COB_MODULE_PTR->statement = STMT_UNKNOWN;
 
 	cobglobptr->cob_stmt_exception = 0;
+
+	cob_push_call_stack_list (*module);
+
 	return 0;
 }
 
@@ -3271,6 +3274,7 @@ cob_module_leave (cob_module *module)
 	COB_UNUSED (module);
 	/* Pop module pointer */
 	COB_MODULE_PTR = COB_MODULE_PTR->next;
+	cob_pop_call_stack_list ();
 }
 
 void

--- a/libcob/common.h
+++ b/libcob/common.h
@@ -1302,6 +1302,14 @@ typedef struct __cob_module {
 
 } cob_module;
 
+/* call stack list for cancel all */
+typedef struct __call_stack_list {
+	struct __call_stack_list	*parent;
+	struct __call_stack_list	*children;
+	struct __call_stack_list	*sister;
+	cob_module 					*module;
+} call_stack_list;
+
 
 /* User function structure */
 
@@ -2058,6 +2066,8 @@ COB_EXPIMP void		*cob_call_field		(const cob_field *,
 COB_EXPIMP void		cob_cancel_field	(const cob_field *,
 						 const struct cob_call_struct *);
 COB_EXPIMP void		cob_cancel		(const char *);
+void				cob_push_call_stack_list (cob_module *); /* CALL from common.c */
+void				cob_pop_call_stack_list (void); /* CALL from common.c */
 COB_EXPIMP int		cob_call_with_exception_check (const char*, const int, void **);
 COB_EXPIMP int		cob_call		(const char *, const int, void **);
 COB_EXPIMP int		cob_func		(const char *, const int, void **);

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -11870,6 +11870,57 @@ SUB GOT Z
 AT_CLEANUP
 
 
+AT_SETUP([CANCEL ALL])
+AT_KEYWORDS([runmisc])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       PROCEDURE        DIVISION.
+           CALL "call01"
+           END-CALL.
+           CANCEL ALL.
+           CALL "call01"
+           END-CALL.
+           STOP RUN.
+])
+
+AT_DATA([call01.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      call01.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       PROCEDURE        DIVISION.
+           CALL "call02"
+           END-CALL.
+           GOBACK.
+])
+
+AT_DATA([call02.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      call02.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 X             PIC 9.
+       PROCEDURE        DIVISION.
+           ADD 1 TO X.
+           DISPLAY X
+           END-DISPLAY.
+           EXIT PROGRAM.
+           GOBACK.
+])
+
+AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE_MODULE} call01.cob])
+AT_CHECK([${COMPILE_MODULE} call02.cob])
+AT_CHECK([./prog], [0],
+[1
+1
+])
+
+AT_CLEANUP
+
+
 AT_SETUP([C-API (param based)])
 AT_KEYWORDS([runmisc CALL api])
 


### PR DESCRIPTION
* See #19 
* Create a call_stack_list structure to store the list of called programs
* Save all call program lists in tree format
* When CANCEL ALL is called, cancel all child elements of the current program.

