### PR TITLE
Fix/pic national

### DIFF
--- a/cobc/codegen.c
+++ b/cobc/codegen.c
@@ -5773,11 +5773,15 @@ output_initialize (struct cb_initialize *p)
 	case INITIALIZE_DEFAULT:
 		c = initialize_uniform_char (f, p);
 		if (c != -1) {
-			if (p->statement == STMT_INIT_STORAGE) {
-				output_init_comment_and_source_ref (f);
+			if ((cb_tree_type (CB_TREE (f), f) == COB_TYPE_NATIONAL) && (c == ' ')) {
+				output_move (cb_space, p->var);
+			} else {
+				if (p->statement == STMT_INIT_STORAGE) {
+					output_init_comment_and_source_ref (f);
+				}
+				output_initialize_uniform (p->var, f, (unsigned char)c, f->size);
+				output_initialize_chaining (f, p);
 			}
-			output_initialize_uniform (p->var, f, (unsigned char)c, f->size);
-			output_initialize_chaining (f, p);
 			return;
 		}
 		/* Fall through */

--- a/cobc/typeck.c
+++ b/cobc/typeck.c
@@ -11459,7 +11459,7 @@ validate_move (cb_tree src, cb_tree dst, const unsigned int is_value, int *move_
 				if (dst_size_mod == FIELD_SIZE_UNKNOWN) {
 					break;
 				}
-				if (size > fdst->size / COB_NATIONAL_SIZE) {
+				if (size > fdst->size) {
 					goto size_overflow_1;
 				}
 				break;
@@ -11471,6 +11471,10 @@ validate_move (cb_tree src, cb_tree dst, const unsigned int is_value, int *move_
 					goto size_overflow_1;
 				}
 				break;
+			case CB_CATEGORY_ALPHANUMERIC:
+				if (size > fdst->size * COB_NATIONAL_SIZE) {
+					goto size_overflow_1;
+				}
 			case CB_CATEGORY_BOOLEAN:
 				/* TODO: add checks */
 				break;

--- a/cobc/typeck.c
+++ b/cobc/typeck.c
@@ -11463,6 +11463,7 @@ validate_move (cb_tree src, cb_tree dst, const unsigned int is_value, int *move_
 					goto size_overflow_1;
 				}
 				break;
+			case CB_CATEGORY_ALPHANUMERIC_EDITED:
 			case CB_CATEGORY_NATIONAL_EDITED:
 				if (dst_size_mod == FIELD_SIZE_UNKNOWN) {
 					break;
@@ -11471,15 +11472,24 @@ validate_move (cb_tree src, cb_tree dst, const unsigned int is_value, int *move_
 					goto size_overflow_1;
 				}
 				break;
+			case CB_CATEGORY_ALPHABETIC:
 			case CB_CATEGORY_ALPHANUMERIC:
 				if (size > fdst->size * COB_NATIONAL_SIZE) {
 					goto size_overflow_1;
 				}
+				break;
 			case CB_CATEGORY_BOOLEAN:
 				/* TODO: add checks */
 				break;
 			default:
-				goto invalid;
+				if (dst_size_mod == FIELD_SIZE_UNKNOWN) {
+					break;
+				}
+				if (size > fdst->size) {
+					goto size_overflow_1;
+				}
+				break;
+			// 	goto invalid;
 			}
 			break;
 		case CB_CATEGORY_NATIONAL_EDITED:

--- a/tests/testsuite.src/i18n_sjis_pic-n.at
+++ b/tests/testsuite.src/i18n_sjis_pic-n.at
@@ -457,3 +457,22 @@ AT_CHECK([${COMPILE} -x prog.cob], [0])
 AT_CHECK([./prog], [0], [゜ポンデソング])
 
 AT_CLEANUP
+
+AT_SETUP([INITIALIZE PIC N.])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 F0 PIC N(5).
+       PROCEDURE        DIVISION.
+           INITIALIZE F0.
+           DISPLAY F0 WITH NO ADVANCING.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} -x prog.cob], [0])
+AT_CHECK([./prog], [0], [　　　　　])
+
+AT_CLEANUP

--- a/tests/testsuite.src/syn_move.at
+++ b/tests/testsuite.src/syn_move.at
@@ -318,11 +318,8 @@ AT_DATA([prog.cob], [
 ])
 
 # unfinished national
-AT_CHECK([$COMPILE_ONLY -Wno-unfinished prog.cob], [1], [],
-[prog.cob:15: error: invalid MOVE statement
-prog.cob:16: error: invalid MOVE statement
-prog.cob:17: error: invalid MOVE statement
-])
+AT_CHECK([$COMPILE_ONLY -Wno-unfinished prog.cob], [0], [],
+[])
 
 AT_CLEANUP
 


### PR DESCRIPTION
Fixed the following errors:

* fixed to generate cob_move when INITIALIZE a NATIONAL item to initialize it with full-width spaces
* MOVE from N item to X item does not cause compile error.