### PR TITLE
Hotfix/move to national error

### DIFF
--- a/libcob/move.c
+++ b/libcob/move.c
@@ -1859,19 +1859,6 @@ cob_move (cob_field *src_in, cob_field *dst)
 		return;
 	}
 
-	if (COB_FIELD_TYPE (src) != COB_TYPE_GROUP) {
-		if ((!(COB_FIELD_TYPE (src) == COB_TYPE_NATIONAL ||
-		       COB_FIELD_TYPE (src) == COB_TYPE_NATIONAL_EDITED)) &&
-		    (COB_FIELD_TYPE (dst) == COB_TYPE_NATIONAL ||
-		     COB_FIELD_TYPE (dst) == COB_TYPE_NATIONAL_EDITED)) {
-			pTmp = judge_hankakujpn_exist (src, dst, &size);
-			if (pTmp != NULL) {
-				src->data = (unsigned char *)pTmp;
-				src->size = size;
-			}
-		}
-	}
-
 	/* Non-elementary move */
 	if (COB_FIELD_TYPE (src) == COB_TYPE_GROUP
 	 || COB_FIELD_TYPE (dst) == COB_TYPE_GROUP) {
@@ -1927,9 +1914,19 @@ cob_move (cob_field *src_in, cob_field *dst)
 				return;
 			}
 		case COB_TYPE_NATIONAL:
+			pTmp = judge_hankakujpn_exist (src, dst, &size);
+			if (pTmp != NULL) {
+				src->data = (unsigned char *)pTmp;
+				src->size = size;
+			}
 			cob_move_alphanum_to_national (src, dst);
 			return;
 		case COB_TYPE_NATIONAL_EDITED:
+			pTmp = judge_hankakujpn_exist (src, dst, &size);
+			if (pTmp != NULL) {
+				src->data = (unsigned char *)pTmp;
+				src->size = size;
+			}
 			cob_move_alphanum_to_national_edited (src, dst);
 			return;
 		default:
@@ -2269,9 +2266,19 @@ cob_move (cob_field *src_in, cob_field *dst)
 			cob_move_alphanum_to_edited (src, dst);
 			return;
 		case COB_TYPE_NATIONAL_EDITED:
+			pTmp = judge_hankakujpn_exist (src, dst, &size);
+			if (pTmp != NULL) {
+				src->data = (unsigned char *)pTmp;
+				src->size = size;
+			}
 			cob_move_alphanum_to_national_edited (src, dst);
 			break;
 		case COB_TYPE_NATIONAL:
+			pTmp = judge_hankakujpn_exist (src, dst, &size);
+			if (pTmp != NULL) {
+				src->data = (unsigned char *)pTmp;
+				src->size = size;
+			}
 			cob_move_alphanum_to_national (src, dst);
 			break;
 		default:

--- a/libcob/move.c
+++ b/libcob/move.c
@@ -1928,10 +1928,10 @@ cob_move (cob_field *src_in, cob_field *dst)
 			}
 		case COB_TYPE_NATIONAL:
 			cob_move_alphanum_to_national (src, dst);
-			break;
+			return;
 		case COB_TYPE_NATIONAL_EDITED:
 			cob_move_alphanum_to_national_edited (src, dst);
-			break;
+			return;
 		default:
 			cob_move_display_to_alphanum (src, dst);
 			return;

--- a/tests/testsuite.src/i18n_sjis_pic-n.at
+++ b/tests/testsuite.src/i18n_sjis_pic-n.at
@@ -497,3 +497,41 @@ AT_CHECK([${COMPILE} -x prog.cob], [0])
 AT_CHECK([./prog], [0], [Å@Å@Å@Å@Å@])
 
 AT_CLEANUP
+
+AT_SETUP([PIC N Move with NUMERIC items.])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 F0 PIC N(5).
+       01 F1 PIC 9(5).
+       01 F2 PIC S9(5).
+       01 F3 PIC 9(5) COMP-3.
+       01 F4 PIC S9(5) COMP.
+       PROCEDURE        DIVISION.
+           MOVE 123 TO F1.
+           MOVE F1 TO F0.
+           DISPLAY F0.
+           MOVE -123 TO F2.
+           MOVE F2 TO F0.
+           DISPLAY F0.
+           MOVE 123 TO F3.
+           MOVE F3 TO F0.
+           DISPLAY F0.
+           MOVE -123 TO F4.
+           MOVE F4 TO F0.
+           DISPLAY F0.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} -x prog.cob], [0])
+AT_CHECK([./prog], [0], 
+[ÇOÇOÇPÇQÇR
+ÇOÇOÇPÇQÇì
+ÇOÇOÇPÇQÇR
+ÇOÇOÇPÇQÇì
+])
+
+AT_CLEANUP


### PR DESCRIPTION
Fixed an error that occurred when moving from a numeric item to a NATIONAL item.

* It is now possible to MOVE to NATIONAL items from PIC 9 DISPLAY, COMP-3, COMP, etc.