### PR TITLE
Fix CI trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: test
 on:
   push:
   pull_request:
-    types: [opened, reopened, review_requested, synchronize]
+    types: [opened, reopened, synchronize]
 
 env:
   CPPFLAGS: "-I/usr/include"

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -3,7 +3,7 @@ name: cppcheck
 on:
   push:
   pull_request:
-    types: [opened, reopened, review_requested, synchronize]
+    types: [opened, reopened, synchronize]
 
 env:
   CPPFLAGS: "-I/usr/include"


### PR DESCRIPTION
I removed the trigger `review_requested` from workflows `ci.yml` and `cppcheck.yml`.
This prevents duplicate runs of the same pipeline.
