### PR TITLE
Use `vbisam-osscons-patch` instead of `opensource-cobol/vbisam`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,15 +48,15 @@ jobs:
       - name: Download vbisam and Build it
         if: steps.vbisam_cache_id.outputs.cache-hit != 'true'
         run: |
-          curl -L -o opensource-cobol-1.5.2J.tar.gz https://github.com/opensourcecobol/opensource-cobol/archive/refs/tags/v1.5.2J.tar.gz
-          tar zxf opensource-cobol-1.5.2J.tar.gz
-          cd opensource-cobol-1.5.2J/vbisam
+          curl -L -o vbisam-osscons-patch-2.0patch1.tar.gz https://github.com/opensourcecobol/vbisam-osscons-patch/archive/refs/tags/v2.0patch1.tar.gz
+          tar zxf vbisam-osscons-patch-2.0patch1.tar.gz
+          cd vbisam-osscons-patch-2.0patch1
           ./configure --prefix=/usr/
           make
 
       # Install vbisam
       - name: Install vbisam
-        working-directory: opensource-cobol-1.5.2J/vbisam
+        working-directory: vbisam-osscons-patch-2.0patch1
         run: |
           make install
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,12 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      # Cache the directory 'opensource-cobol-1.5.2J/vbisam'
+      # Cache the directory 'vbisam'
       - name: Cache vbisam
         id: vbisam_cache_id
         uses: actions/cache@v4
         with:
-          path: opensource-cobol/vbisam
+          path: vbisam-osscons-patch-2.0patch1
           key: vbisam-${{ matrix.os }}-key
 
       # Download vbisam and Build it

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -24,9 +24,8 @@ jobs:
 
       - name: Download vbisam
         run: |
-          if [ ! -d vbisam ]; then \
+          if [ ! -d vbisam-osscons-patch ]; then \
             git clone https://github.com/opensourcecobol/vbisam-osscons-patch.git; \
-            mv vbisam-osscons-patch .; \
           fi
 
       - name: Install vbisam

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -25,13 +25,12 @@ jobs:
       - name: Download vbisam
         run: |
           if [ ! -d vbisam ]; then \
-            git clone https://github.com/opensourcecobol/opensource-cobol; \
-            mv opensource-cobol/vbisam .; \
-            rm -rf opensource-cobol; \
+            git clone https://github.com/opensourcecobol/vbisam-osscons-patch.git; \
+            mv vbisam-osscons-patch .; \
           fi
 
       - name: Install vbisam
-        working-directory: vbisam
+        working-directory: vbisam-osscons-patch
         run: |
           ./configure --prefix=/usr/
           make


### PR DESCRIPTION
GnuCOBOL is built with the `--with-vbisam` option, using VBISAM from opensource COBOL.
So I update CI to use `vbisam-osscons-patch`.